### PR TITLE
fix/personality-upload-issues: feedback for data with missing rows

### DIFF
--- a/frontend/src/pages/ImportBelbin.jsx
+++ b/frontend/src/pages/ImportBelbin.jsx
@@ -159,7 +159,7 @@ function ImportPage() {
         })
             .then((response) => {
                 if (!response.ok) {
-                    throw new Error('Error sending data to the REST API');
+                    response.json().then(json => console.log(json))
                 }
             })
             .catch((error) => {

--- a/frontend/src/pages/ImportEffort.jsx
+++ b/frontend/src/pages/ImportEffort.jsx
@@ -158,7 +158,7 @@ function InfoImporter() {
         })
             .then((response) => {
                 if (!response.ok) {
-                    throw new Error('Error sending data to the REST API');
+                    response.json().then(json => console.log(json))
                 }
             })
             .catch((error) => {


### PR DESCRIPTION
Update

- the app does not allow users to upload personality data unless all enrolled students are addressed in the data

Not addressed

- while the frontend logs the feedback, it is not visualised for the client